### PR TITLE
Add UI for easily creating new links from a JID or URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,21 +23,46 @@
 <body>
   <div class="main">
     <noscript><h3>You need JavaScript to follow the invitation.</h3></noscript>
-    <h3 class="text-center" id="heading"></h3>
-    <p class="text-center"><a class="btn btn-primary" id="button"></a></p>
-    <input type="url" class="form-control text-center" id="url_in" readonly/>
-    <div class="qrcode" id="qrcode"></div>
+    <div id="display-uri" style="display:none">
+        <h3 class="text-center" id="heading" data-i18n=".heading"></h3>
+        <p class="text-center"><a class="btn btn-primary" id="button" data-i18n=".button"></a></p>
+        <input type="url" class="form-control text-center" id="url_in" readonly/>
+        <div class="qrcode" id="qrcode"></div>
 
-    <p class="lead text-center" id="clients"></p>
-    <p class="lead text-center" id="recommend"></p>
+        <p class="lead text-center" id="clients" data-i18n="clients"></p>
+        <p class="lead text-center" id="recommend" data-i18n="recommend"></p>
 
-    <p class="lead img-center text-center" id="client_list"></p>
+        <p class="lead img-center text-center" id="client_list"></p>
 
-    <i>
-      <p class="hint text-center" id="checkfulllist"></p>
-      <p class="hint text-center" id="xmppis"></p>
-    </i>
-    <p class="hint text-center" id="xmpp"></p>
+        <i>
+        <p class="hint text-center" id="checkfulllist" data-i18n="checkfulllist" data-i18n-target="innerHTML"></p>
+        <p class="hint text-center" id="xmppis" data-i18n="xmppis"></p>
+        </i>
+        <p class="hint text-center" id="xmpp"></p>
+    </div>
+    <div id="enter-uri" style="width:80%;display: none;">
+        <h3 class="text-center" id="enter-heading" data-i18n="create.heading"></h3>
+        <p data-i18n="create.desc"></p>
+        <div style="width: 90%;margin: 0 auto;">
+                <label for="uri_input" data-i18n="create.input"></label>
+                <input class="uri-input" id="uri_input" name="uri_input" type="text"/>
+                <div class="input-group">
+                        <input type="checkbox" id="is_muc" name="is_muc" value="muc">
+                        <label for="is_muc" data-i18n="create.is_muc"></label>
+                </div>
+
+                <button id="generate-link-btn" data-i18n="create.button"></button>
+
+		<div id="display-link" style="display:none">
+	                <h4 data-i18n="create.link_heading"></h4>
+	                <div class="text-center">
+	                <a id="generated-link" href=""></a><br/>
+	                <a href="#" class="btn" data-i18n="action-copy" id="copy-link"></a>
+	                <div id="copy-result"></div>
+	                </div>
+                </div>
+        </div>
+    </div>
   </div>
   <script src="scripts/i18n-text.min.js"></script>
   <script src="config.js"></script>

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,6 +11,12 @@
     "button": "Join the chat room {{name}}",
     "":""
   },
+  "register": {
+    "title": "Invitation to {{name}}",
+    "heading": "You have been invited to create an account on {{name}}",
+    "button": "Register on {{name}}",
+    "":""
+  },
   "create": {
     "title": "Create XMPP link",
     "heading": "Create an XMPP link",

--- a/lang/en.json
+++ b/lang/en.json
@@ -11,9 +11,22 @@
     "button": "Join the chat room {{name}}",
     "":""
   },
+  "create": {
+    "title": "Create XMPP link",
+    "heading": "Create an XMPP link",
+    "desc": "Use this to create a quick friendly XMPP link you can share with people. Enter or paste an XMPP URI or JID below to begin.",
+    "button": "Generate link",
+    "input": "JID or URI:",
+    "is_muc": "This is a group chat",
+    "link_heading": "Your link",
+    "":""
+  },
   "clients": "You need to install an XMPP client to access the XMPP network.",
   "recommend": "Here are the most commonly used clients for your platform:",
   "checkfulllist": "See the <a href='https://xmpp.org/software/clients/'>full list</a> of XMPP clients for other platforms and devices.",
   "xmppis": "XMPP is a provider-independent kind of instant messaging where a wide selection of clients and servers allows you to participate.",
+  "action-copy": "Copy to clipboard",
+  "copy-success": "Copied!",
+  "copy-failure": "Failed to copy to clipboard",
   "":""
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -187,9 +187,13 @@
 		Promise.resolve().then(function () {
 			return navigator.clipboard.writeText(link.href);
 		}).then(function () {
-			copy_result_el.innerText = i18n.text("copy-success");
+			get_translated_string('copy-success', {}).then(function (text) {
+				copy_result_el.innerText = text;
+			});
 		}, function () {
-			copy_result_el.innerText = i18n.text("copy-failure");
+			get_translated_string('copy-failure', {}).then(function (text) {
+				copy_result_el.innerText = text;
+			});
 		}).finally(function () {
 			copy_result_el.style.visibility = "visible";
 		});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -201,6 +201,12 @@
 			document.getElementById("display-link").style.display = "block";
 		});
 		document.getElementById("uri_input").addEventListener("input", generate_link);
+		document.getElementById("uri_input").addEventListener("keyup", function(event) {
+			event.preventDefault();
+			if (event.keyCode === 13) {
+				document.getElementById("generate-link-btn").click();
+			}
+		});
 		document.getElementById("is_muc").addEventListener("change", generate_link);
 		document.getElementById("copy-link").addEventListener("click", copy_to_clipboard);
 	}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -32,7 +32,6 @@
 	}
 
 	function load_hash() {
-		var muc = false;
 		key_prefix = "chat";
 		var xmpp_uri = window.location.search || window.location.hash;
 		xmpp_uri = decodeURIComponent(xmpp_uri.substring(xmpp_uri.indexOf('#') + 1, xmpp_uri.length));
@@ -47,12 +46,13 @@
 			// ignore error, JID wasn't base64 encoded
 		}
 		if (xmpp_uri.search("\\?join") >= 0) {
-			muc = true;
 			key_prefix = "muc";
+		} else if(xmpp_uri.search("\\?register") >= 0) {
+			key_prefix = "register";
 		}
 
 		// TODO: proper error checking / display / Creation of invitations
-		if (xmpp_uri.search("@") <= 0) return {xmpp_uri:xmpp_uri, xmpp_uri_encoded:xmpp_uri, name: xmpp_uri};
+		if (xmpp_uri.search("@") <= 0) return {xmpp_uri:xmpp_uri, xmpp_uri_encoded:xmpp_uri, name: xmpp_uri.split("?")[0]};
 
 		var xmpp_params = {};
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -33,7 +33,7 @@
 
 	function load_hash() {
 		var muc = false;
-		key_prefix = "chat.";
+		key_prefix = "chat";
 		var xmpp_uri = window.location.search || window.location.hash;
 		xmpp_uri = decodeURIComponent(xmpp_uri.substring(xmpp_uri.indexOf('#') + 1, xmpp_uri.length));
 		if (xmpp_uri.indexOf("xmpp:") === 0) {
@@ -48,7 +48,7 @@
 		}
 		if (xmpp_uri.search("\\?join") >= 0) {
 			muc = true;
-			key_prefix = "muc.";
+			key_prefix = "muc";
 		}
 
 		// TODO: proper error checking / display / Creation of invitations
@@ -82,28 +82,106 @@
 
 	function translate_ui() {
 		// translation
-		document.title = i18n.text(key_prefix + 'title',  display_data);
-		// MUC/chat specific
-		['heading', 'button'].forEach(function(id) {
-			document.getElementById(id).innerText = i18n.text(key_prefix + id, display_data);
-		});
-		// and agnostic
-		['clients', 'recommend', 'checkfulllist', 'xmppis'].forEach(function(id) {
-			/* innerHTML needed to display links and markup from translation */
-			document.getElementById(id).innerHTML = i18n.text(id, {});
+		try {
+			document.title = i18n.text(key_prefix + '.title',  display_data);
+		} catch {
+		}
+
+		let translatable_els = document.querySelectorAll("[data-i18n]");
+
+		translatable_els.forEach(function (el) {
+			let key = el.dataset.i18n;
+			if(key.startsWith(".")) {
+				key = key_prefix + key;
+			}
+			let text;
+			try {
+				text = i18n.text(key, display_data);
+			} catch {
+				text = "UNTRANSLATED[" + key + "]";
+			}
+			let target = el.dataset.i18nTarget || "innerText";
+			if(target.startsWith("@")) {
+				el.setAttribute(target.substr(1), text);
+			} else {
+				el[target] = text;
+			}
 		});
 	}
 
 	function rehash() {
-		display_data = load_hash();
-		document.getElementById('button').href = "xmpp:" + display_data.xmpp_uri_encoded;
-		document.getElementById('url_in').value = "xmpp:" + display_data.xmpp_uri;
+		let hash = window.location.search || window.location.hash;
+		if(!hash || hash == "#") {
+			// Input mode
+			document.getElementById("display-uri").style.display = "none";
+			document.getElementById("enter-uri").style.display = "block";
+			initialize_uri_input();
+			key_prefix = "create";
+		} else {
+			document.getElementById("display-uri").style.display = "block";
+			document.getElementById("enter-uri").style.display = "none";
+
+			display_data = load_hash();
+			document.getElementById('button').href = "xmpp:" + display_data.xmpp_uri_encoded;
+			document.getElementById('url_in').value = "xmpp:" + display_data.xmpp_uri;
+		}
 		translate_ui();
 	}
 
 	function createQR() {
 		display_data = load_hash();
 		new QRCode(document.getElementById("qrcode"), "xmpp:" + display_data.xmpp_uri_encoded);
+	}
+
+	function generate_link() {
+		let input_el = document.getElementById("uri_input");
+		let output_el = document.getElementById("generated-link");
+		let is_muc_el = document.getElementById("is_muc");
+
+		let input = input_el.value;
+		var uri;
+
+		if(!(input.indexOf("xmpp:") == 0)) {
+			uri = "xmpp:" + input;
+			if(is_muc_el.checked) {
+				uri += "?join";
+			}
+			is_muc_el.disabled = false;
+		} else {
+			uri = decodeURIComponent(input);
+			is_muc_el.disabled = true;
+			is_muc_el.checked = uri.endsWith("?join");
+		}
+
+		let encoded_uri = uri.substr(5).split("@").map(encodeURIComponent).join("@");
+
+		let link = document.location.origin + document.location.pathname + "#" + encoded_uri;
+		output_el.href = link;
+		output_el.innerText = link;
+	}
+
+	function copy_to_clipboard() {
+		let link = document.getElementById("generated-link");
+		let copy_result_el = document.getElementById("copy-result");
+		Promise.resolve().then(function () {
+			return navigator.clipboard.writeText(link.href);
+		}).then(function () {
+			copy_result_el.innerText = i18n.text("copy-success");
+		}, function () {
+			copy_result_el.innerText = i18n.text("copy-failure");
+		}).finally(function () {
+			copy_result_el.style.visibility = "visible";
+		});
+	}
+
+	function initialize_uri_input() {
+		document.getElementById("generate-link-btn").addEventListener("click", function () {
+			generate_link();
+			document.getElementById("display-link").style.display = "block";
+		});
+		document.getElementById("uri_input").addEventListener("input", generate_link);
+		document.getElementById("is_muc").addEventListener("change", generate_link);
+		document.getElementById("copy-link").addEventListener("click", copy_to_clipboard);
 	}
 
 	function load_done() {
@@ -178,16 +256,16 @@
 			load_done();
 		}
 	};
-	
+
 	var logo = document.createElement('img');
 	logo.src = 'assets/xmpp.svg';
 	logo.alt= 'XMPP logo';
 	logo.width = 60;
-	
+
 	var link = document.createElement('a');
 	link.href = 'https://xmpp.org/';
 	link.append(logo)
-	
+
 	var brand = document.getElementById('xmpp');
 	brand.append(link)
 })();

--- a/stylesheets/i.css
+++ b/stylesheets/i.css
@@ -79,3 +79,22 @@ li {
 	height: 100%;
 	margin: auto;
 }
+
+.uri-input {
+        width: 100%;
+        padding: 5px !important;
+        border: solid black 1px !important;
+        margin-top: 0.25em;
+}
+
+.input-group {
+        margin: 0;
+        padding: 0;
+        margin-bottom: 0.75em !important;
+}
+
+.input-group input {
+        background-color: red !important;
+        margin-top: 0.5em !important;
+        margin-left: 0px !important;
+}


### PR DESCRIPTION
This makes it easy for people to create a shareable link by entering a JID or URI, and avoids them having to manually construct URLs and deal with escaping. The resulting URL can be visited directly, or copied to the clipboard with a button.

To simplify the code, it also changes how translation is applied (it now uses data attributes on elements).

TODO: There are some new strings that need translating.

(this PR is based on a local feature branch, and replaces the original PR at #61)