### PR TITLE
Client config revamp

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -45,7 +45,7 @@
 	"gajim": {
 		"title": "Gajim",
 		"linux": "https://gajim.org",
-		"windows": "https://gajim.org"
+		"windows": "https://apps.microsoft.com/store/detail/9PGGF6HD43F9?launch=true&mode=mini"
 	},
 	"psi": {
 		"title": "Psi",
@@ -63,4 +63,3 @@
 		"web": "https://join.movim.eu/"
 	}
 }
-	

--- a/clients.json
+++ b/clients.json
@@ -1,0 +1,66 @@
+{
+	"yaxim": {
+		"title": "yaxim",
+		"android": "https://play.google.com/store/apps/details?id=org.yaxim.androidclient"
+	},
+	"conversations": {
+		"title": "Conversations",
+		"android": "https://play.google.com/store/apps/details?id=eu.siacs.conversations"
+	},
+	"cheogram": {
+		"title": "Cheogram",
+		"android": "https://play.google.com/store/apps/details?id=com.cheogram.android.playstore"
+	},
+	"bruno": {
+		"title": "Bruno",
+		"logo": "assets/bruno.png",
+		"android": "https://play.google.com/store/apps/details?id=org.yaxim.bruno"
+	},
+	"monocles": {
+		"title": "Monocles",
+		"android": "https://play.google.com/store/apps/details?id=eu.monocles.chat"
+	},
+	"monal": {
+		"title": "Monal IM",
+		"ios": "https://apps.apple.com/us/app/monal-free-xmpp-chat/id317711500",
+		"macos": "https://monal.im"
+	},
+	"siskin": {
+		"title": "Siskin IM",
+		"logo": "assets/siskin.jpeg",
+		"ios": "https://apps.apple.com/us/app/tigase-messenger/id1153516838"
+	},
+	"dino": {
+		"title": "Dino",
+		"linux": "https://dino.im"
+	},
+	"kaidan": {
+		"title": "Kaidan",
+		"linux": "https://www.kaidan.im/"
+	},
+	"conversejs": {
+		"title": "Converse",
+		"web": "https://conversejs.org/"
+	},
+	"gajim": {
+		"title": "Gajim",
+		"linux": "https://gajim.org",
+		"windows": "https://gajim.org"
+	},
+	"psi": {
+		"title": "Psi",
+		"logo": "assets/psi.png",
+		"linux": "https://psi-im.org",
+		"macos": "https://psi-im.org",
+		"windows": "https://psi-im.org"
+	},
+	"uwpx": {
+		"title": "UWPX",
+		"windows": "https://uwpx.org"
+	},
+	"movim": {
+		"title": "Movim",
+		"web": "https://join.movim.eu/"
+	}
+}
+	

--- a/clients_Android.json
+++ b/clients_Android.json
@@ -1,7 +1,0 @@
-[
-    "<a href=\"https://play.google.com/store/apps/details?id=org.yaxim.androidclient\"><img src=\"assets/yaxim.svg\" height=\"60\">yaxim</a>",
-    "<a href=\"https://play.google.com/store/apps/details?id=eu.siacs.conversations\"><img src=\"assets/conversations.svg\" height=\"60\">Conversations</a>",
-    "<a href=\"https://play.google.com/store/apps/details?id=com.cheogram.android.playstore\"><img src=\"assets/cheogram.svg\" height=\"60\">Cheogram</a>",
-    "<a href=\"https://play.google.com/store/apps/details?id=org.yaxim.bruno\"><img src=\"assets/bruno.png\" height=\"60\">Bruno</a>",
-    "<a href=\"https://play.google.com/store/apps/details?id=eu.monocles.chat\"><img src=\"assets/monocles.svg\" height=\"60\">Monocles</a>"
-]

--- a/clients_Linux.json
+++ b/clients_Linux.json
@@ -1,7 +1,0 @@
-[
-    "<a href=\"https://dino.im/\"><img src=\"assets/dino.svg\" height=\"60\">Dino</a>",
-    "<a href=\"https://www.kaidan.im/\"><img src=\"assets/kaidan.svg\" height=\"60\">Kaidan</a>",
-    "<a href=\"https://conversejs.org/\"><img src=\"assets/conversejs.svg\" height=\"60\">Converse</a>",
-    "<a href=\"https://gajim.org/\"><img src=\"assets/gajim.svg\" height=\"60\">Gajim</a>",
-    "<a href=\"https://psi-im.org/\"><img src=\"assets/psi.png\" height=\"60\">Psi</a>"
-]

--- a/clients_OSX.json
+++ b/clients_OSX.json
@@ -1,7 +1,0 @@
-[
-    "<a href=\"https://jitsi.org/\"><img src=\"assets/jitsi.svg\" height=\"60\">Jitsi</a>",
-    "<a href=\"https://swift.im/\"><img src=\"assets/swift.svg\" height=\"60\">Swift</a>",
-    "<a href=\"https://monal.im/\"><img src=\"assets/monal.svg\" height=\"60\">Monal</a>",
-    "<a href=\"https://conversejs.org/\"><img src=\"assets/conversejs.svg\" height=\"60\">Converse</a>",
-    "<a href=\"https://psi-im.org/\"><img src=\"assets/psi.png\" height=\"60\">Psi</a>"
-]

--- a/clients_Tizen.json
+++ b/clients_Tizen.json
@@ -1,6 +1,0 @@
-[
-    "<a href=\"https://jitsi.org/\"><img src=\"assets/jitsi.svg\" height=\"60\">Jitsi</a>",
-    "<a href=\"https://loqui.im/\"><img src=\"assets/loqui.svg\" height=\"60\">Loqui</a>",
-    "<a href=\"https://iotivity.org/\"><img src=\"assets/iotivity.svg\" height=\"60\">IoTivity</a>",
-    "<a href=\"https://nimbuzz.com/\"><img src=\"assets/nimbuzz.svg\" height=\"60\">Nimbuzz</a>"
-]

--- a/clients_Windows.json
+++ b/clients_Windows.json
@@ -1,7 +1,0 @@
-[
-    "<a href=\"https://jitsi.org/\"><img src=\"assets/jitsi.svg\" height=\"60\">Jitsi</a>",
-    "<a href=\"https://swift.im/\"><img src=\"assets/swift.svg\" height=\"60\">Swift</a>",
-    "<a href=\"https://uwpx.org/\"><img src=\"assets/uwpx.svg\" height=\"60\">UWPX</a>",
-    "<a href=\"https://conversejs.org/\"><img src=\"assets/conversejs.svg\" height=\"60\">Converse</a>",
-    "<a href=\"https://psi-im.org/\"><img src=\"assets/psi.png\" height=\"60\">Psi</a>"
-]

--- a/clients_iOS.json
+++ b/clients_iOS.json
@@ -1,6 +1,0 @@
-[
-    "<a href=\"https://apps.apple.com/us/app/jitsi-meet/id1165103905\"><img src=\"assets/jitsi.svg\" height=\"60\">Jitsi</a>",
-    "<a href=\"https://apps.apple.com/us/app/tigase-messenger/id1153516838\"><img src=\"assets/siskin.jpeg\" height=\"60\">Siskin IM</a>",
-    "<a href=\"https://apps.apple.com/us/app/monal-free-xmpp-chat/id317711500\"><img src=\"assets/monal.svg\" height=\"60\">Monal</a>",
-    "<a href=\"https://apps.apple.com/us/app/chatsecure/id464200063\"><img src=\"assets/chatsecure.svg\" height=\"60\">ChatSecure</a>"
-]

--- a/config.js.dist
+++ b/config.js.dist
@@ -1,2 +1,31 @@
 var supportedLocales = ['de', 'en', 'fr', 'he', 'pl', 'ro']
 var defaultLocale = 'en'
+
+// If you use the default app list, but want to hide some, add them here
+var hidden_apps = [
+	// "example-app"
+]
+
+// Alternatively, if any apps are listed here, no other apps will be listed
+var only_apps = [
+]
+
+// Apps listed here will be listed first, and have a star icon. The defaults
+// here are those with up-to-date "advanced" compliance for IM, per xmpp.org.
+var star_apps = [
+	"conversations",
+	"monocles",
+	"dino",
+]
+
+// You can add custom apps here, which will be merged with the default list
+// It's also possible to override existing apps in the list with custom
+// metadata.
+var custom_apps = {
+/*
+	"my-app": {
+		"title": "My XMPP App",
+		"windows": "https://example.com"
+	}
+*/
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -86,13 +86,15 @@
 			}
 
 			// Prefer starred clients
-			let a_is_starred = star_apps.includes(a);
-			let b_is_starred = star_apps.includes(b);
+			if(star_apps && star_apps.length > 0) {
+				let a_is_starred = star_apps.includes(a);
+				let b_is_starred = star_apps.includes(b);
 
-			if(a_is_starred && !b_is_starred) {
-				return -1;
-			} else if(b_is_starred && !a_is_starred) {
-				return 1;
+				if(a_is_starred && !b_is_starred) {
+					return -1;
+				} else if(b_is_starred && !a_is_starred) {
+					return 1;
+				}
 			}
 
 			// Sort lexically by title

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -36,6 +36,13 @@
 		link.setAttribute("href", client_info[platform]);
 		let logo_url = client_info.logo || ("assets/" + client_id + ".svg");
 		img.setAttribute("src", logo_url);
+		if(star_apps && star_apps.includes(client_id)) {
+			let star_el = document.createElement("div");
+			star_el.innerText = "\u2B50";
+			star_el.classList.add("star");
+			item.classList.add("starred");
+			link.append(star_el);
+		}
 		link.append(img, client_info.title);
 		item.append(link);
 		item.classList.add("client-link");

--- a/stylesheets/i.css
+++ b/stylesheets/i.css
@@ -141,3 +141,10 @@ li {
 	height: 5rem;
 	padding: 2rem !important;
 }
+
+.star {
+	width: 5rem;
+	text-align: left;
+	position: absolute;
+	font-size: 16pt;
+}

--- a/stylesheets/i.css
+++ b/stylesheets/i.css
@@ -135,3 +135,9 @@ li {
 		background: rgb(59 73 99);
 	}
 }
+
+.client-link {
+	width: 5rem;
+	height: 5rem;
+	padding: 2rem !important;
+}


### PR DESCRIPTION
This branch adds a new config mechanism to control the client listings.

Notable changes:

- All the clients are now maintained in a single JSON file
- The site owner can now, via config.js:
  - Add additional custom entries (or override existing ones)
  - Hide apps certain they don't want to display
  - Only show a list of specific apps
  - Configure certain apps as "starred" - which displays a visible star and moves them to the front of the list
- The apps are now sorted:
  - Starred apps are shown first, then...
  - Apps native to the user's platform are preferred
  - Web apps are shown for all platforms, behind native apps (if any)
  - After that, the clients are sorted lexically by name

The plan is to have clients.json open to any clients that pass the basic compliance suites. The default starred apps are those that have "advanced" in both the core and IM compliance suites.