### PR TITLE
remove QR code color inversion

### DIFF
--- a/stylesheets/i.css
+++ b/stylesheets/i.css
@@ -129,10 +129,6 @@ li {
         outline: 1px solid rgb(73 83 94);
     }
 
-    .qrcode img {
-        filter: invert(1);
-    }
-
     .hint {
         color: rgb(204 204 204);
     }


### PR DESCRIPTION
The QR code does not work in dark mode because the image itself is
inverted using CSS but the background, acting as quite area, is not.

This PR solves this by removing the inversion filter.

<details><summary>before</summary>

<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/61b84d08-61a3-4fcf-8139-b5fd6cefd296" />

</details>

<details><summary>after</summary>

<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/b034f891-541c-4e4a-a250-fb7acfc0693e" />

</details>