### PR TITLE
invert QR code quiet area

### DIFF
--- a/stylesheets/i.css
+++ b/stylesheets/i.css
@@ -129,6 +129,10 @@ li {
         outline: 1px solid rgb(73 83 94);
     }
 
+    .qrcode {
+        background-color: black;
+    }
+
     .qrcode img {
         filter: invert(1);
     }


### PR DESCRIPTION
The QR code does not work in dark mode because the image itself is
inverted using CSS but the background, acting as quite area, is not.

This PR solves this by also inverting the background.

<details><summary>before</summary>

<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/61b84d08-61a3-4fcf-8139-b5fd6cefd296" />

</details>

<details><summary>after</summary>

<img width="412" height="915" alt="image" src="https://github.com/user-attachments/assets/db445fda-686b-4fd4-814f-521d464d5b6c" />

</details>