### PR TITLE
fix: Wrap long names to prevent layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
   <noscript><h1>You need JavaScript to follow the invitation.</h1></noscript>
   <div id="display-uri" style="display: none;">
     <div class="content box mt-4 p-4 flex flex-col gap-2">
-      <h1 id="heading" data-i18n=".heading"></h1>
+      <h1 id="heading" class="wrap-anywhere" data-i18n=".heading"></h1>
       <div class="flex items-center justify-between gap-2">
         <input type="url" id="url_in" class="w-full" readonly/>
         <a href="#" class="btn btn-regular text-nowrap" data-i18n="action-copy" data-i18n-target="title" id="copy-jid-link">📋</a>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -306,11 +306,14 @@ a:hover {
 .w-full {
   width: 100%;
 }
+.text-center {
+  text-align: center;
+}
 .text-nowrap {
   text-wrap: nowrap;
 }
-.text-center {
-  text-align: center;
+.wrap-anywhere {
+  overflow-wrap: anywhere;
 }
 .truncate {
   text-overflow: ellipsis;


### PR DESCRIPTION
In connection with recent style changes, this fixes #98 

<img width="433" height="770" alt="image" src="https://github.com/user-attachments/assets/1025d93f-9adc-4407-b695-8461f117985e" />
